### PR TITLE
[DevOps] fix header regex

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,11 +11,13 @@ IncludeCategories:
     Priority: 2
   - Regex: '^".*/API.*.hpp'
     Priority: 3
-  - Regex: '^<.*.h'
+  - Regex: '^<.*.h>'
     Priority: 4
-  - Regex: '^<.*'
+  - Regex: '^<.*.hpp>'
     Priority: 5
-  - Regex: '^".*.hpp'
+  - Regex: '^<.*>'
+    Priority: 6
+  - Regex: '^".*.hpp"'
     Priority: 1
 
 AlignArrayOfStructures: Right

--- a/src/Lib/Gamepad/Gamepad.cpp
+++ b/src/Lib/Gamepad/Gamepad.cpp
@@ -3,9 +3,10 @@
 #include "Logger/Logger.hpp"
 
 #include <GLFW/glfw3.h>
-#include <algorithm>
+
 #include <boost/container/flat_set.hpp>
 
+#include <algorithm>
 #include <string_view>
 
 namespace {

--- a/src/Lib/Logger/Logger.hpp
+++ b/src/Lib/Logger/Logger.hpp
@@ -1,10 +1,10 @@
 #ifndef CLIENT_LOGGER_HPP
 #define CLIENT_LOGGER_HPP
-#include <chrono>
 #include <imgui.h>
 
 #include <array>
 #include <cassert>
+#include <chrono>
 #include <fstream>
 #include <sstream>
 


### PR DESCRIPTION
* old regex incorrectly sort headers with 'h' character, this commit fix this